### PR TITLE
feat: add RSS feed

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,6 +13,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found | Mike Tattersall</title>
+    <link rel="alternate" type="application/rss+xml" title="Mike Tattersall — Blog" href="feed.xml">
     <link rel="stylesheet" href="style.css">
 </head>
 

--- a/blogs/building-effective-teams-to-solve-problems.html
+++ b/blogs/building-effective-teams-to-solve-problems.html
@@ -19,6 +19,7 @@
     <meta property="og:url" content="https://miketattersall.com/blogs/building-effective-teams-to-solve-problems.html">
     <meta property="og:image" content="https://miketattersall.com/images/mike.png">
     <meta name="twitter:card" content="summary">
+    <link rel="alternate" type="application/rss+xml" title="Mike Tattersall — Blog" href="../feed.xml">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>

--- a/blogs/my-product-management-principles.html
+++ b/blogs/my-product-management-principles.html
@@ -19,6 +19,7 @@
     <meta property="og:url" content="https://miketattersall.com/blogs/my-product-management-principles.html">
     <meta property="og:image" content="https://miketattersall.com/images/mike.png">
     <meta name="twitter:card" content="summary">
+    <link rel="alternate" type="application/rss+xml" title="Mike Tattersall — Blog" href="../feed.xml">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>

--- a/blogs/product-management-in-government.html
+++ b/blogs/product-management-in-government.html
@@ -19,6 +19,7 @@
     <meta property="og:url" content="https://miketattersall.com/blogs/product-management-in-government.html">
     <meta property="og:image" content="https://miketattersall.com/images/mike.png">
     <meta name="twitter:card" content="summary">
+    <link rel="alternate" type="application/rss+xml" title="Mike Tattersall — Blog" href="../feed.xml">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>

--- a/blogs/productivity.html
+++ b/blogs/productivity.html
@@ -19,6 +19,7 @@
     <meta property="og:url" content="https://miketattersall.com/blogs/productivity.html">
     <meta property="og:image" content="https://miketattersall.com/images/mike.png">
     <meta name="twitter:card" content="summary">
+    <link rel="alternate" type="application/rss+xml" title="Mike Tattersall — Blog" href="../feed.xml">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>

--- a/blogs/service-design.html
+++ b/blogs/service-design.html
@@ -19,6 +19,7 @@
     <meta property="og:url" content="https://miketattersall.com/blogs/service-design.html">
     <meta property="og:image" content="https://miketattersall.com/images/mike.png">
     <meta name="twitter:card" content="summary">
+    <link rel="alternate" type="application/rss+xml" title="Mike Tattersall — Blog" href="../feed.xml">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>

--- a/career-history.html
+++ b/career-history.html
@@ -20,6 +20,7 @@
     <meta property="og:url" content="https://miketattersall.com/career-history.html">
     <meta property="og:image" content="https://miketattersall.com/images/mike.png">
     <meta name="twitter:card" content="summary">
+    <link rel="alternate" type="application/rss+xml" title="Mike Tattersall — Blog" href="feed.xml">
     <link rel="stylesheet" href="style.css">
 </head>
 

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Mike Tattersall — Blog</title>
+    <link>https://miketattersall.com/</link>
+    <atom:link href="https://miketattersall.com/feed.xml" rel="self" type="application/rss+xml" />
+    <description>Writing on product management, service design, and delivery leadership from Mike Tattersall, Product Manager and Chief Delivery Officer at Hippo Digital.</description>
+    <language>en-gb</language>
+    <managingEditor>michaelrwtattersall@gmail.com (Mike Tattersall)</managingEditor>
+    <item>
+      <title>My productivity system</title>
+      <link>https://miketattersall.com/blogs/productivity.html</link>
+      <guid isPermaLink="true">https://miketattersall.com/blogs/productivity.html</guid>
+      <pubDate>Wed, 28 Aug 2024 09:00:00 +0100</pubDate>
+      <description>A simple flowchart-based productivity system for managing incoming tasks — actionable or not, delegate or do, immediate or scheduled.</description>
+    </item>
+    <item>
+      <title>Service Design</title>
+      <link>https://miketattersall.com/blogs/service-design.html</link>
+      <guid isPermaLink="true">https://miketattersall.com/blogs/service-design.html</guid>
+      <pubDate>Sun, 12 Feb 2023 09:00:00 +0000</pubDate>
+      <description>What service design is, what service designers do, and how service blueprints fit alongside user research and analytics.</description>
+    </item>
+    <item>
+      <title>My product management principles</title>
+      <link>https://miketattersall.com/blogs/my-product-management-principles.html</link>
+      <guid isPermaLink="true">https://miketattersall.com/blogs/my-product-management-principles.html</guid>
+      <pubDate>Sun, 12 Feb 2023 09:00:00 +0000</pubDate>
+      <description>Seven principles that guide my approach to product management — from starting with why and designing for real people to measuring what matters.</description>
+    </item>
+    <item>
+      <title>Product management in government</title>
+      <link>https://miketattersall.com/blogs/product-management-in-government.html</link>
+      <guid isPermaLink="true">https://miketattersall.com/blogs/product-management-in-government.html</guid>
+      <pubDate>Sun, 12 Feb 2023 09:00:00 +0000</pubDate>
+      <description>Product management in government is shaped by users, policy, stakeholders and service context — not profit. The unique challenges and skills it demands.</description>
+    </item>
+    <item>
+      <title>Building effective teams to solve problems</title>
+      <link>https://miketattersall.com/blogs/building-effective-teams-to-solve-problems.html</link>
+      <guid isPermaLink="true">https://miketattersall.com/blogs/building-effective-teams-to-solve-problems.html</guid>
+      <pubDate>Sun, 12 Feb 2023 09:00:00 +0000</pubDate>
+      <description>Effective problem-solving teams start by understanding the problem, build around skills not job titles, and scale only when communication can hold up.</description>
+    </item>
+  </channel>
+</rss>

--- a/footer.html
+++ b/footer.html
@@ -3,7 +3,8 @@
         <p>Website made by Mike Tattersall</p>
         <a href="https://twitter.com/tmikes18" target="_blank">@tmikes18 on X (formally Twitter)</a> |
         <a href="https://bsky.app/profile/tmikes18.bsky.social">@tmikes18 on BlueSky</a> |
-        <a href="https://www.linkedin.com/in/mike-tattersall-03b41a93/" target="_blank">My LinkedIn Profile</a> | 
-        <a href="mailto:michaelrwtattersall@gmail.com">Email Me</a>
+        <a href="https://www.linkedin.com/in/mike-tattersall-03b41a93/" target="_blank">My LinkedIn Profile</a> |
+        <a href="mailto:michaelrwtattersall@gmail.com">Email Me</a> |
+        <a href="/feed.xml">RSS</a>
     </div>
 </footer>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <meta property="og:url" content="https://miketattersall.com/">
     <meta property="og:image" content="https://miketattersall.com/images/mike.png">
     <meta name="twitter:card" content="summary">
+    <link rel="alternate" type="application/rss+xml" title="Mike Tattersall — Blog" href="feed.xml">
     <link rel="stylesheet" href="style.css">
 </head>
 


### PR DESCRIPTION
## Summary
- New \`feed.xml\` at the site root listing all six current posts
- \`<link rel=\"alternate\" type=\"application/rss+xml\">\` added to every page's \`<head>\` so feed readers can autodiscover
- Visible \"RSS\" link added to the footer

## Why
- Every comparable personal site in the gov-digital / product space offers RSS; without it there is no way for readers to subscribe and return
- Closes one of the highest-leverage gaps for compounding readership over time

## Notes
- Touches the \`<head>\` of the same 8 HTML files as the SEO PR; whichever lands second will need a quick rebase
- After deploy, \`feed.xml\` should be reachable at \`https://miketatterall.com/feed.xml\` and validate via https://validator.w3.org/feed/
- New posts need a new \`<item>\` block in \`feed.xml\` (small manual step until/unless we move to a static-site generator)

## Test plan
- [ ] After merge & deploy, fetch \`/feed.xml\` and confirm it parses
- [ ] Subscribe in a feed reader and confirm all six posts appear
- [ ] View source on any page and confirm the \`<link rel=\"alternate\">\` resolves