### PR TITLE
a11y: blog cards as anchor elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,31 +32,30 @@
 
         <h2>Blog</h2>
         <div class="blog-grid">
-            <div class="blog-card" onclick="window.location.href='blogs/productivity.html'">
+            <a class="blog-card" href="blogs/productivity.html">
                 <h3>My Productivity System</h3>
                 <span class="post-date">28th August 2024</span>
-            </div>
-            <div class="blog-card" onclick="window.location.href='blogs/july-2024.html'">
+            </a>
+            <a class="blog-card" href="blogs/july-2024.html">
                 <h3>July Month Post</h3>
                 <span class="post-date">31st July 2024</span>
-            </div>
-            <div class="blog-card" onclick="window.location.href='blogs/service-design.html'">
+            </a>
+            <a class="blog-card" href="blogs/service-design.html">
                 <h3>Service Design</h3>
                 <span class="post-date">12th February 2023</span>
-            </div>
-            <div class="blog-card" onclick="window.location.href='blogs/my-product-management-principles.html'">
+            </a>
+            <a class="blog-card" href="blogs/my-product-management-principles.html">
                 <h3>My Product Management Principles</h3>
                 <span class="post-date">12th February 2023</span>
-            </div>
-            <div class="blog-card" onclick="window.location.href='blogs/product-management-in-government.html'">
+            </a>
+            <a class="blog-card" href="blogs/product-management-in-government.html">
                 <h3>Product Management In Government</h3>
                 <span class="post-date">12th February 2023</span>
-            </div>
-            <div class="blog-card"
-                onclick="window.location.href='blogs/building-effective-teams-to-solve-problems.html'">
+            </a>
+            <a class="blog-card" href="blogs/building-effective-teams-to-solve-problems.html">
                 <h3>Building Effective Teams to Solve Problems</h3>
                 <span class="post-date">12th February 2023</span>
-            </div>
+            </a>
         </div>
 
         <h2>More</h2>

--- a/style.css
+++ b/style.css
@@ -191,12 +191,19 @@ main {
     justify-content: space-between;
     height: 100%;
     box-sizing: border-box;
+    text-decoration: none;
+    color: inherit;
 }
 
 .blog-card:hover {
     transform: translateY(-4px);
     box-shadow: var(--shadow-lg);
     border-color: transparent;
+}
+
+.blog-card:focus-visible {
+    outline: 3px solid var(--primary-color);
+    outline-offset: 2px;
 }
 
 .blog-card h3 {


### PR DESCRIPTION
## Summary
- Replaces \`<div class=\"blog-card\" onclick=\"window.location.href=...\">\` with \`<a class=\"blog-card\" href=\"...\">\` for the six blog cards on the homepage
- Adds \`text-decoration: none\` and \`color: inherit\` to \`.blog-card\` so anchors look identical to the previous divs
- Adds a \`:focus-visible\` outline so keyboard users can see which card is focused

## Why
The previous \`div + onclick\` pattern broke several things that real links provide for free:
- Keyboard users could not tab to or activate the cards
- Right-click / cmd-click \"open in new tab\" did nothing
- Screen readers announced them as generic divs rather than links
- The browser status bar showed no URL preview on hover

## Test plan
- [ ] Tab through the homepage; confirm a focus ring appears on each blog card
- [ ] Press Enter on a focused card and confirm it navigates
- [ ] Cmd-click (or middle-click) a card and confirm it opens in a new tab
- [ ] Visually confirm cards still look the same as before