### PR TITLE
fix: remove broken link to deleted July 2024 post

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,6 @@
                 <h3>My Productivity System</h3>
                 <span class="post-date">28th August 2024</span>
             </a>
-            <a href="blogs/july-2024.html" class="blog-card" data-title="July Month Post" data-tags="personal reflection monthly">
-                <h3>July Month Post</h3>
-                <span class="post-date">31st July 2024</span>
-            </a>
             <a href="blogs/service-design.html" class="blog-card" data-title="Service Design" data-tags="service-design design">
                 <h3>Service Design</h3>
                 <span class="post-date">12th February 2023</span>


### PR DESCRIPTION
## Summary
Removes the homepage blog card pointing to \`blogs/july-2024.html\`, which was deleted in 1bf6502. The link previously 404'd.

## Test plan
- [ ] Confirm the homepage blog grid no longer shows \"July Month Post\"
- [ ] Confirm no other page references the deleted post