### PR TITLE
Add 'Writing elsewhere' section with external blog posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,13 +90,17 @@
 
         <h3 style="margin-top: 1.5rem; margin-bottom: 0.5rem;">Hippo Digital</h3>
         <div class="blog-grid">
-            <a href="https://hippodigital.co.uk/insights/a-positive-approach-to-risk-mitigation-requires-human-centred-thinking/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="A positive approach to risk mitigation requires human-centred thinking" data-tags="hippo risk human-centred">
-                <h3>A positive approach to risk mitigation requires human-centred thinking</h3>
-                <span class="post-date">Hippo Digital</span>
+            <a href="https://hippodigital.co.uk/insights/most-organisations-arent-ready-for-ai/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Most organisations aren't ready for AI" data-tags="hippo ai">
+                <h3>Most organisations aren't ready for AI</h3>
+                <span class="post-date">March 2026</span>
             </a>
             <a href="https://hippodigital.co.uk/insights/product-management-mindsets-agile-adaptable-by-nature/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Product Management Mindsets: Agile & adaptable by nature" data-tags="hippo product-management agile">
                 <h3>Product Management Mindsets: Agile &amp; adaptable by nature</h3>
-                <span class="post-date">Hippo Digital</span>
+                <span class="post-date">June 2025</span>
+            </a>
+            <a href="https://hippodigital.co.uk/insights/a-positive-approach-to-risk-mitigation-requires-human-centred-thinking/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="A positive approach to risk mitigation requires human-centred thinking" data-tags="hippo risk human-centred">
+                <h3>A positive approach to risk mitigation requires human-centred thinking</h3>
+                <span class="post-date">September 2022</span>
             </a>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -63,6 +63,43 @@
             </a>
         </div>
 
+        <h2>Writing elsewhere</h2>
+        <h3 style="margin-top: 1.5rem; margin-bottom: 0.5rem;">DWP Digital</h3>
+        <div class="blog-grid">
+            <a href="https://dwpdigital.blog.gov.uk/2015/06/04/business-subject-matter-experts-get-one-or-two/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Business Subject Matter Experts – Get one (or two)" data-tags="dwp government">
+                <h3>Business Subject Matter Experts – Get one (or two)</h3>
+                <span class="post-date">4th June 2015</span>
+            </a>
+            <a href="https://dwpdigital.blog.gov.uk/2014/10/27/for-staff-with-staff-improving-the-digital-back-office/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="For staff, with staff – Improving the digital back office" data-tags="dwp government">
+                <h3>For staff, with staff – Improving the digital back office</h3>
+                <span class="post-date">27th October 2014</span>
+            </a>
+            <a href="https://dwpdigital.blog.gov.uk/2014/07/01/user-needs-take-the-lead/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="User needs take the lead" data-tags="dwp government user-needs">
+                <h3>User needs take the lead</h3>
+                <span class="post-date">1st July 2014</span>
+            </a>
+        </div>
+
+        <h3 style="margin-top: 1.5rem; margin-bottom: 0.5rem;">GDS / Services in Government</h3>
+        <div class="blog-grid">
+            <a href="https://services.blog.gov.uk/2021/08/03/building-a-single-sign-on-for-government-what-weve-learnt-so-far/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Building a single sign-on for government: What we've learnt so far" data-tags="gds government sso">
+                <h3>Building a single sign-on for government: What we've learnt so far</h3>
+                <span class="post-date">3rd August 2021</span>
+            </a>
+        </div>
+
+        <h3 style="margin-top: 1.5rem; margin-bottom: 0.5rem;">Hippo Digital</h3>
+        <div class="blog-grid">
+            <a href="https://hippodigital.co.uk/insights/a-positive-approach-to-risk-mitigation-requires-human-centred-thinking/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="A positive approach to risk mitigation requires human-centred thinking" data-tags="hippo risk human-centred">
+                <h3>A positive approach to risk mitigation requires human-centred thinking</h3>
+                <span class="post-date">Hippo Digital</span>
+            </a>
+            <a href="https://hippodigital.co.uk/insights/product-management-mindsets-agile-adaptable-by-nature/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Product Management Mindsets: Agile & adaptable by nature" data-tags="hippo product-management agile">
+                <h3>Product Management Mindsets: Agile &amp; adaptable by nature</h3>
+                <span class="post-date">Hippo Digital</span>
+            </a>
+        </div>
+
         <h2>More</h2>
         <div style="margin-top: 20px;">
             <a href="career-history.html" class="button">Find out more about my career &rarr;</a>


### PR DESCRIPTION
## Summary

- Adds a new "Writing elsewhere" section to the homepage linking to blog posts written for other publications
- DWP Digital: 3 posts (2014–2015)
- GDS / Services in Government: 1 post (2021)
- Hippo Digital: 3 posts (2022–2026), including a new AI post from March 2026
- All external links open in a new tab
- Posts ordered newest first within each section
- All cards included in the existing blog search

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmL2q1TxQUKnP23nf3LMts)_