### PR TITLE
Merge all blog posts into one unified grid with publication labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,62 +41,65 @@
             <input type="search" id="blog-search" placeholder="Search posts..." aria-label="Search blog posts">
         </div>
         <div class="blog-grid">
-            <a href="blogs/productivity.html" class="blog-card" data-title="My Productivity System" data-tags="productivity tools">
-                <h3>My Productivity System</h3>
-                <span class="post-date">28th August 2024</span>
-            </a>
-            <a href="blogs/service-design.html" class="blog-card" data-title="Service Design" data-tags="service-design design">
-                <h3>Service Design</h3>
-                <span class="post-date">12th February 2023</span>
-            </a>
-            <a href="blogs/my-product-management-principles.html" class="blog-card" data-title="My Product Management Principles" data-tags="product-management">
-                <h3>My Product Management Principles</h3>
-                <span class="post-date">12th February 2023</span>
-            </a>
-            <a href="blogs/product-management-in-government.html" class="blog-card" data-title="Product Management In Government" data-tags="product-management government">
-                <h3>Product Management In Government</h3>
-                <span class="post-date">12th February 2023</span>
-            </a>
-            <a href="blogs/building-effective-teams-to-solve-problems.html" class="blog-card" data-title="Building Effective Teams to Solve Problems" data-tags="teams leadership">
-                <h3>Building Effective Teams to Solve Problems</h3>
-                <span class="post-date">12th February 2023</span>
-            </a>
-        </div>
-
-        <h2>Writing elsewhere</h2>
-        <h3 style="margin-top: 1.5rem; margin-bottom: 0.5rem;">Hippo Digital</h3>
-        <div class="blog-grid">
             <a href="https://hippodigital.co.uk/insights/most-organisations-arent-ready-for-ai/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Most organisations aren't ready for AI" data-tags="hippo ai">
                 <h3>Most organisations aren't ready for AI</h3>
                 <span class="post-date">March 2026</span>
+                <span class="post-source">Hippo Digital</span>
             </a>
             <a href="https://hippodigital.co.uk/insights/product-management-mindsets-agile-adaptable-by-nature/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Product Management Mindsets: Agile & adaptable by nature" data-tags="hippo product-management agile">
                 <h3>Product Management Mindsets: Agile &amp; adaptable by nature</h3>
                 <span class="post-date">June 2025</span>
+                <span class="post-source">Hippo Digital</span>
+            </a>
+            <a href="blogs/productivity.html" class="blog-card" data-title="My Productivity System" data-tags="productivity tools">
+                <h3>My Productivity System</h3>
+                <span class="post-date">28th August 2024</span>
+                <span class="post-source">miketattersall.com</span>
+            </a>
+            <a href="blogs/service-design.html" class="blog-card" data-title="Service Design" data-tags="service-design design">
+                <h3>Service Design</h3>
+                <span class="post-date">12th February 2023</span>
+                <span class="post-source">miketattersall.com</span>
+            </a>
+            <a href="blogs/my-product-management-principles.html" class="blog-card" data-title="My Product Management Principles" data-tags="product-management">
+                <h3>My Product Management Principles</h3>
+                <span class="post-date">12th February 2023</span>
+                <span class="post-source">miketattersall.com</span>
+            </a>
+            <a href="blogs/product-management-in-government.html" class="blog-card" data-title="Product Management In Government" data-tags="product-management government">
+                <h3>Product Management In Government</h3>
+                <span class="post-date">12th February 2023</span>
+                <span class="post-source">miketattersall.com</span>
+            </a>
+            <a href="blogs/building-effective-teams-to-solve-problems.html" class="blog-card" data-title="Building Effective Teams to Solve Problems" data-tags="teams leadership">
+                <h3>Building Effective Teams to Solve Problems</h3>
+                <span class="post-date">12th February 2023</span>
+                <span class="post-source">miketattersall.com</span>
             </a>
             <a href="https://hippodigital.co.uk/insights/a-positive-approach-to-risk-mitigation-requires-human-centred-thinking/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="A positive approach to risk mitigation requires human-centred thinking" data-tags="hippo risk human-centred">
                 <h3>A positive approach to risk mitigation requires human-centred thinking</h3>
                 <span class="post-date">September 2022</span>
+                <span class="post-source">Hippo Digital</span>
             </a>
-        </div>
-
-        <h3 style="margin-top: 1.5rem; margin-bottom: 0.5rem;">Government</h3>
-        <div class="blog-grid">
             <a href="https://services.blog.gov.uk/2021/08/03/building-a-single-sign-on-for-government-what-weve-learnt-so-far/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Building a single sign-on for government: What we've learnt so far" data-tags="gds government sso">
                 <h3>Building a single sign-on for government: What we've learnt so far</h3>
                 <span class="post-date">3rd August 2021</span>
+                <span class="post-source">GDS / Services in Government</span>
             </a>
             <a href="https://dwpdigital.blog.gov.uk/2015/06/04/business-subject-matter-experts-get-one-or-two/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="Business Subject Matter Experts – Get one (or two)" data-tags="dwp government">
                 <h3>Business Subject Matter Experts – Get one (or two)</h3>
                 <span class="post-date">4th June 2015</span>
+                <span class="post-source">DWP Digital</span>
             </a>
             <a href="https://dwpdigital.blog.gov.uk/2014/10/27/for-staff-with-staff-improving-the-digital-back-office/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="For staff, with staff – Improving the digital back office" data-tags="dwp government">
                 <h3>For staff, with staff – Improving the digital back office</h3>
                 <span class="post-date">27th October 2014</span>
+                <span class="post-source">DWP Digital</span>
             </a>
             <a href="https://dwpdigital.blog.gov.uk/2014/07/01/user-needs-take-the-lead/" class="blog-card" target="_blank" rel="noopener noreferrer" data-title="User needs take the lead" data-tags="dwp government user-needs">
                 <h3>User needs take the lead</h3>
                 <span class="post-date">1st July 2014</span>
+                <span class="post-source">DWP Digital</span>
             </a>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -213,6 +213,13 @@ main {
     margin-top: auto;
 }
 
+.blog-card .post-source {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 4px;
+    font-style: italic;
+}
+
 a.blog-card {
     text-decoration: none;
     color: inherit;


### PR DESCRIPTION
## Summary

- Removes the separate "Writing elsewhere" section
- Merges all 12 posts into a single "Blog" grid, sorted newest first
- Each card now shows where it was written (miketattersall.com, Hippo Digital, DWP Digital, GDS / Services in Government)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmL2q1TxQUKnP23nf3LMts)_