### PR TITLE
Update CDO career history with expanded detail

### DIFF
--- a/career-history.html
+++ b/career-history.html
@@ -32,22 +32,37 @@
         <p>With over 17 years of experience, I have progressed through various roles within the public sector and
             digital consultancy, focusing on product management, service design, and digital transformation. My career
             is marked by a commitment to delivering user-centred digital services, fostering effective agile delivery
-            cultures and delivering business objectives</p>
-        <p>Currently, as Chief Delivery Officer at Hippo Digital, I lead the delivery of digital services that meet our
-            clients' needs, overseeing a team that has grown from 60 to over 700 professionals. My work has directly
-            contributed to significant client wins and the successful delivery of numerous projects. I am also leading
-            Hippo's AI transformation, shaping how we deliver for clients.</p>
+            cultures, and delivering business objectives — including M&amp;A activity, commercial strategy, and
+            AI-enabled transformation.</p>
+        <p>Currently, as Chief Delivery Officer at Hippo Digital, a leading UK public sector digital consultancy, I lead
+            the quality, consistency, and commercial performance of delivery across a portfolio spanning NHS England, DWP,
+            DfE, MoJ, and the BBC. I have grown the permanent consultant workforce from 60 to over 700 professionals and
+            am leading Hippo's AI transformation — shaping how we use AI to accelerate delivery for clients as a
+            structural change to how consulting engagements are designed and executed.</p>
         <h3>Key Career Milestones</h3>
-        <p>Chief Delivery Officer, Hippo Digital (Aug 2023 - Present): In this leadership role, I oversee the delivery
-            of digital services, ensuring they meet client needs and user outcomes. I have successfully scaled the
-            consultant team from 60 to over 700 professionals, significantly improved the permanent vs contractor ratio,
-            and led organisational restructuring to support growth. My strategic direction has resulted in the
-            successful delivery of 99% of projects on time, with a 9/10 client satisfaction rating, alongside securing
-            new clients across various government departments and the BBC. I am also leading Hippo's AI transformation,
-            shaping how we deliver for clients.</p>
+        <p>Chief Delivery Officer, Hippo Digital (Aug 2023 - Present): As Chief Delivery Officer, I am responsible for
+            the quality, consistency, and commercial performance of delivery across a portfolio spanning NHS England, DWP,
+            DfE, MoJ, and the BBC. Since taking the role I have scaled the permanent consultant workforce from 60 to over
+            700 professionals, significantly improving the permanent-to-contractor ratio to build a more sustainable,
+            high-quality delivery model. Alongside headcount growth I led a structural reorganisation, introducing sector
+            verticals across Health, Education, Central Government, and Private sectors, underpinned by a cross-cutting
+            professions layer, giving Hippo the architecture to grow without losing coherence. Delivery outcomes have
+            remained consistently strong throughout: 99% of projects delivered on time, with a client satisfaction rating
+            of 9/10.</p>
+        <p>A significant focus of my current work is Hippo's AI transformation — shaping how we use AI to accelerate
+            delivery for clients, not just as a tool but as a structural change to how consulting engagements are designed
+            and executed. This includes leading the AI Accelerator initiative, developing AI-augmented delivery
+            methodologies for the public sector, and positioning Hippo's frameworks-led approach as the foundation for
+            outcomes-based, AI-enabled programmes.</p>
+        <p>Following Hippo's acquisition by Exponent Private Equity in March 2025, I have also played a central role in
+            the company's strategic positioning for growth, contributing to M&amp;A analysis, Investment Committee papers,
+            and the commercial strategy underpinning our next phase.</p>
         <p>Interim Chief Commercial Officer, Hippo Digital (Dec 2025 - Jun 2026): Alongside my CDO responsibilities,
-            I covered the Chief Commercial Officer role on an interim basis, during which we achieved our highest ever
-            new wins and sales orders.</p>
+            I covered the Chief Commercial Officer role on an interim basis for six months, leading the commercial
+            function at a period of significant market opportunity. During this period Hippo achieved its highest ever new
+            wins and sales orders — a result of tightening our go-to-market approach, strengthening bid quality, and
+            embedding commercial discipline more deeply into delivery conversations. I also brought in and onboarded a
+            permanent Commercial Director to succeed me in the role.</p>
         <p>Director of Service and Delivery, Hippo Digital (Jun 2021 - Jul 2023): I represented Service and Delivery at
             the board level, focusing on scaling our consultancy services and enhancing our delivery capabilities. My
             achievements include the expansion of our consultant base and the implementation of a more sustainable

--- a/career-history.html
+++ b/career-history.html
@@ -32,12 +32,12 @@
         <p>With over 17 years of experience, I have progressed through various roles within the public sector and
             digital consultancy, focusing on product management, service design, and digital transformation. My career
             is marked by a commitment to delivering user-centred digital services, fostering effective agile delivery
-            cultures, and delivering business objectives — including M&amp;A activity, commercial strategy, and
+            cultures, and delivering business objectives, including M&amp;A activity, commercial strategy, and
             AI-enabled transformation.</p>
         <p>Currently, as Chief Delivery Officer at Hippo Digital, a leading UK public sector digital consultancy, I lead
             the quality, consistency, and commercial performance of delivery across a portfolio spanning NHS England, DWP,
             DfE, MoJ, and the BBC. I have grown the permanent consultant workforce from 60 to over 700 professionals and
-            am leading Hippo's AI transformation — shaping how we use AI to accelerate delivery for clients as a
+            am leading Hippo's AI transformation, shaping how we use AI to accelerate delivery for clients as a
             structural change to how consulting engagements are designed and executed.</p>
         <h3>Key Career Milestones</h3>
         <p>Chief Delivery Officer, Hippo Digital (Aug 2023 - Present): As Chief Delivery Officer, I am responsible for
@@ -46,10 +46,11 @@
             700 professionals, significantly improving the permanent-to-contractor ratio to build a more sustainable,
             high-quality delivery model. Alongside headcount growth I led a structural reorganisation, introducing sector
             verticals across Health, Education, Central Government, and Private sectors, underpinned by a cross-cutting
-            professions layer, giving Hippo the architecture to grow without losing coherence. Delivery outcomes have
-            remained consistently strong throughout: 99% of projects delivered on time, with a client satisfaction rating
-            of 9/10.</p>
-        <p>A significant focus of my current work is Hippo's AI transformation — shaping how we use AI to accelerate
+            professions layer, and built dedicated delivery leadership teams within each sector to oversee delivery and
+            reduce reliance on any single point of accountability. This gives Hippo the architecture to grow without
+            losing coherence. Delivery outcomes have remained consistently strong throughout: 99% of projects delivered
+            on time, with a client satisfaction rating of 9/10.</p>
+        <p>A significant focus of my current work is Hippo's AI transformation, shaping how we use AI to accelerate
             delivery for clients, not just as a tool but as a structural change to how consulting engagements are designed
             and executed. This includes leading the AI Accelerator initiative, developing AI-augmented delivery
             methodologies for the public sector, and positioning Hippo's frameworks-led approach as the foundation for
@@ -60,7 +61,7 @@
         <p>Interim Chief Commercial Officer, Hippo Digital (Dec 2025 - Jun 2026): Alongside my CDO responsibilities,
             I covered the Chief Commercial Officer role on an interim basis for six months, leading the commercial
             function at a period of significant market opportunity. During this period Hippo achieved its highest ever new
-            wins and sales orders — a result of tightening our go-to-market approach, strengthening bid quality, and
+            wins and sales orders, a result of tightening our go-to-market approach, strengthening bid quality, and
             embedding commercial discipline more deeply into delivery conversations. I also brought in and onboarded a
             permanent Commercial Director to succeed me in the role.</p>
         <p>Director of Service and Delivery, Hippo Digital (Jun 2021 - Jul 2023): I represented Service and Delivery at

--- a/career-history.html
+++ b/career-history.html
@@ -34,15 +34,20 @@
             is marked by a commitment to delivering user-centred digital services, fostering effective agile delivery
             cultures and delivering business objectives</p>
         <p>Currently, as Chief Delivery Officer at Hippo Digital, I lead the delivery of digital services that meet our
-            clients' needs, overseeing a team that has grown from 60 to over 300 professionals. My work has directly
-            contributed to significant client wins and the successful delivery of numerous projects.</p>
+            clients' needs, overseeing a team that has grown from 60 to over 700 professionals. My work has directly
+            contributed to significant client wins and the successful delivery of numerous projects. I am also leading
+            Hippo's AI transformation, shaping how we deliver for clients.</p>
         <h3>Key Career Milestones</h3>
         <p>Chief Delivery Officer, Hippo Digital (Aug 2023 - Present): In this leadership role, I oversee the delivery
             of digital services, ensuring they meet client needs and user outcomes. I have successfully scaled the
-            consultant team from 60 to over 300 professionals, significantly improved the permanent vs contractor ratio,
+            consultant team from 60 to over 700 professionals, significantly improved the permanent vs contractor ratio,
             and led organisational restructuring to support growth. My strategic direction has resulted in the
-            successful delivery of 99% of projects on time and to client satisfaction, alongside securing new clients
-            across various government departments and the BBC.</p>
+            successful delivery of 99% of projects on time, with a 9/10 client satisfaction rating, alongside securing
+            new clients across various government departments and the BBC. I am also leading Hippo's AI transformation,
+            shaping how we deliver for clients.</p>
+        <p>Interim Chief Commercial Officer, Hippo Digital (Dec 2025 - Jun 2026): Alongside my CDO responsibilities,
+            I covered the Chief Commercial Officer role on an interim basis, during which we achieved our highest ever
+            new wins and sales orders.</p>
         <p>Director of Service and Delivery, Hippo Digital (Jun 2021 - Jul 2023): I represented Service and Delivery at
             the board level, focusing on scaling our consultancy services and enhancing our delivery capabilities. My
             achievements include the expansion of our consultant base and the implementation of a more sustainable


### PR DESCRIPTION
## Summary

- Removes all em-dashes from the career history page
- Expands CDO entry with full detail: sector verticals, dedicated delivery leadership teams per sector, AI Accelerator, PE acquisition/M&A work
- Expands interim CCO entry with go-to-market detail and CCO handover
- Updates career summary intro to reflect broader scope

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmL2q1TxQUKnP23nf3LMts)_